### PR TITLE
release: 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+## 1.0.0 (2022-12-22)
+
+
+### :robot: Continuous Integration
+
+* add [@dependabot](https://github.com/dependabot) config ([32d154c](https://github.com/flex-development/export-regex/commit/32d154cd57171bb5316d4db42cca15625d99af72))
+
+
+### :pencil: Documentation
+
+* use + api ([51b74b6](https://github.com/flex-development/export-regex/commit/51b74b6337532fa5e6e8efdb9a910df2e104e155))
+
+
+### :sparkles: Features
+
+* **regex:** `EXPORT_AGGREGATE_REGEX` ([a84be11](https://github.com/flex-development/export-regex/commit/a84be11ca18e53d92aaa99b66c7e3081e701177e))
+* **regex:** `EXPORT_DECLARATION_REGEX` ([089eaa2](https://github.com/flex-development/export-regex/commit/089eaa2a0a94a44b45cd7b15169285da7e76f1ce))
+* **regex:** `EXPORT_DEFAULT_REGEX` ([fe19bc7](https://github.com/flex-development/export-regex/commit/fe19bc78836daa63934bbbbd0d7db16fc5d09c23))
+* **regex:** `EXPORT_LIST_REGEX` ([711bd7e](https://github.com/flex-development/export-regex/commit/711bd7e0cb38a7f521f30db716a73687773af3c5))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flex-development/export-regex",
   "description": "Export statement regex",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "keywords": [
     "ecmascript",
     "export",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

- bumped version to `1.0.0`
- added `CHANGELOG` entry for `1.0.0`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

```sh
  RUN  v0.26.2
      Coverage enabled with c8

 ✓ src/__tests__/export-aggregate.spec.ts > unit:EXPORT_AGGREGATE_REGEX > comments > should ignore export in multi-line comment
 ✓ src/__tests__/export-aggregate.spec.ts > unit:EXPORT_AGGREGATE_REGEX > comments > should ignore export in single-line comment
 ✓ src/__tests__/export-aggregate.spec.ts > unit:EXPORT_AGGREGATE_REGEX > exports > should match named export(s) in multi-line statement
 ✓ src/__tests__/export-aggregate.spec.ts > unit:EXPORT_AGGREGATE_REGEX > exports > should match named export(s) in single-line statement
 ✓ src/__tests__/export-aggregate.spec.ts > unit:EXPORT_AGGREGATE_REGEX > exports > should match named type export(s) in multi-line statement
 ✓ src/__tests__/export-aggregate.spec.ts > unit:EXPORT_AGGREGATE_REGEX > exports > should match named type export(s) in single-line statement
 ✓ src/__tests__/export-aggregate.spec.ts > unit:EXPORT_AGGREGATE_REGEX > exports > should match namespace export
 ✓ src/__tests__/export-aggregate.spec.ts > unit:EXPORT_AGGREGATE_REGEX > exports > should match namespace export with alias
 ✓ src/__tests__/export-list.spec.ts > unit:EXPORT_LIST_REGEX > comments > should ignore export in multi-line comment
 ✓ src/__tests__/export-list.spec.ts > unit:EXPORT_LIST_REGEX > comments > should ignore export in single-line comment
 ✓ src/__tests__/export-list.spec.ts > unit:EXPORT_LIST_REGEX > exports > should match named export(s) in multi-line statement
 ✓ src/__tests__/export-list.spec.ts > unit:EXPORT_LIST_REGEX > exports > should match named export(s) in single-line statement
 ✓ src/__tests__/export-list.spec.ts > unit:EXPORT_LIST_REGEX > exports > should match named type export(s) in multi-line statement
 ✓ src/__tests__/export-list.spec.ts > unit:EXPORT_LIST_REGEX > exports > should match named type export(s) in single-line statement
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > comments > should ignore export in multi-line comment
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > comments > should ignore export in single-line comment
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > class > should match export default abstract class [identifier]
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > class > should match export default abstract class
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > class > should match export default class [identifier]
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > class > should match export default class
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > const enum > should match export default const enum [identifier]
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > enum > should match export default enum [identifier]
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > expressions > should match export default [identifier]
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > expressions > should match export default
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > expressions > should match export default async
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > function > should match export default async function [identifier]
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > function > should match export default async function
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > function > should match export default function [identifier]
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > function > should match export default function
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > function* > should match export default async function* [identifier]
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > function* > should match export default async function*
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > function* > should match export default function* [identifier]
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > function* > should match export default function*
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > interface > should match export default interface [identifier]
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > namespace > should match export default namespace [identifier]
 ✓ src/__tests__/export-default.spec.ts > unit:EXPORT_DEFAULT_REGEX > exports > type > should match export default type [identifier]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > comments > should ignore export in multi-line comment
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > comments > should ignore export in single-line comment
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > class > should match export abstract class [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > class > should match export class [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > class > should match export declare abstract class [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > const enum > should match export const enum [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > const enum > should match export declare const enum [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > const > should match export const [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > const > should match export declare const [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > enum > should match export declare enum [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > enum > should match export enum [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > function > should match export async function [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > function > should match export declare async function [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > function > should match export declare function [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > function > should match export function [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > function* > should match export async function* [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > function* > should match export declare async function* [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > function* > should match export declare function* [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > function* > should match export function* [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > interface > should match export declare interface [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > interface > should match export interface [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > let > should match export declare let [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > let > should match export let [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > namespace > should match export declare namespace [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > namespace > should match export namespace [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > type > should match export declare type [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > type > should match export type [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > var > should match export declare var [exports]
 ✓ src/__tests__/export-declaration.spec.ts > unit:EXPORT_DECLARATION_REGEX > exports > var > should match export var [exports]

 Test Files  4 passed (4)
      Tests  65 passed (65)
   Start at  20:31:44
   Duration  2.24s (transform 608ms, setup 1.46s, collect 257ms, tests 107ms)

 % Coverage report from c8
-----------------------|---------|----------|---------|---------|-------------------
File                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------|---------|----------|---------|---------|-------------------
All files              |     100 |      100 |     100 |     100 |                   
 export-aggregate.ts   |     100 |      100 |     100 |     100 |                   
 export-declaration.ts |     100 |      100 |     100 |     100 |                   
 export-default.ts     |     100 |      100 |     100 |     100 |                   
 export-list.ts        |     100 |      100 |     100 |     100 |                   
-----------------------|---------|----------|---------|---------|-------------------
```

### `yarn pack -o %s-%v.tgz`

```sh
➤ YN0036: Calling the "prepack" lifecycle script
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT ℹ Building @flex-development/export-regex
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT ✔ Build succeeded for @flex-development/export-regex
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT   dist (total size: 24.9 kB)
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT   └─ dist/export-aggregate.mjs.map (130 B)
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT   └─ dist/export-aggregate.mjs (407 B)
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT   └─ dist/export-aggregate.d.mts (2.21 kB)
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT   └─ dist/export-declaration.mjs.map (132 B)
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT   └─ dist/export-declaration.mjs (575 B)
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT   └─ dist/export-declaration.d.mts (9.61 kB)
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT   └─ dist/export-default.mjs.map (128 B)
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT   └─ dist/export-default.mjs (460 B)
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT   └─ dist/export-default.d.mts (8.34 kB)
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT   └─ dist/export-list.mjs.map (125 B)
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT   └─ dist/export-list.mjs (248 B)
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT   └─ dist/export-list.d.mts (1.64 kB)
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT   └─ dist/index.mjs.map (194 B)
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT   └─ dist/index.mjs (420 B)
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT   └─ dist/index.d.mts (339 B)
➤ YN0000: @flex-development/export-regex@workspace:. STDOUT Σ Total build size: 24.9 kB
➤ YN0000: CHANGELOG.md
➤ YN0000: LICENSE.md
➤ YN0000: README.md
➤ YN0000: changelog.config.cts
➤ YN0000: dist/export-aggregate.d.mts
➤ YN0000: dist/export-aggregate.mjs
➤ YN0000: dist/export-aggregate.mjs.map
➤ YN0000: dist/export-declaration.d.mts
➤ YN0000: dist/export-declaration.mjs
➤ YN0000: dist/export-declaration.mjs.map
➤ YN0000: dist/export-default.d.mts
➤ YN0000: dist/export-default.mjs
➤ YN0000: dist/export-default.mjs.map
➤ YN0000: dist/export-list.d.mts
➤ YN0000: dist/export-list.mjs
➤ YN0000: dist/export-list.mjs.map
➤ YN0000: dist/index.d.mts
➤ YN0000: dist/index.mjs
➤ YN0000: dist/index.mjs.map
➤ YN0000: package.json
➤ YN0000: src/export-aggregate.ts
➤ YN0000: src/export-declaration.ts
➤ YN0000: src/export-default.ts
➤ YN0000: src/export-list.ts
➤ YN0000: src/index.ts
➤ YN0036: Calling the "postpack" lifecycle script
➤ YN0000: Package archive generated in ./@flex-development-export-regex-1.0.0.tgz
➤ YN0000: Done in 3s 980ms
```

## Linked issues

<!--
A list of linked issues and/or pull requests.

- <closes|fixes|resolves> #<issue-number>
- <prereleases|releases> #<pr-number>
-->

N/A

## Related documents

<!-- A list of related documents (e.g. docs, proposals, specs, etc), if any. -->

N/A

## Additional context

<!-- Include additional details here. Be sure to note if any tolerable vulnerabilities or warnings have been introduced. -->

N/A

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/export-regex/blob/main/CONTRIBUTING.md#pull-request-titles
